### PR TITLE
package correction for Crossbar v20.4.1 example

### DIFF
--- a/rest/subscriber/.crossbar/config.json
+++ b/rest/subscriber/.crossbar/config.json
@@ -68,7 +68,7 @@
             "components": [
                 {
                     "type": "class",
-                    "classname": "crossbar.adapter.rest.MessageForwarder",
+                    "classname": "crossbar.bridge.rest.MessageForwarder",
                     "realm": "realm1",
                     "extra": {
                         "subscriptions": [


### PR DESCRIPTION
adapter package is not there in Crossbar v20.4.1 and this example should update the current structure which has bridge package!